### PR TITLE
Add console output

### DIFF
--- a/charlotte_core/src/framebuffer/console.rs
+++ b/charlotte_core/src/framebuffer/console.rs
@@ -173,6 +173,7 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
     ($($arg:tt)*) => {
-        CONSOLE.lock().write_fmt(format_args!(concat!($($arg,)* "\n"))).unwrap();
+        CONSOLE.lock().write_fmt(format_args!($($arg)*)).unwrap();
+        CONSOLE.lock().write_char('\n', 0xFFFFFFFF);
     }
 }

--- a/charlotte_core/src/framebuffer/console.rs
+++ b/charlotte_core/src/framebuffer/console.rs
@@ -1,0 +1,178 @@
+use core::fmt;
+use spin::mutex::TicketMutex;
+
+use crate::framebuffer::{framebuffer::FRAMEBUFFER, chars::{FONT_HEIGHT, FONT_WIDTH}};
+
+const CONSOLE_WIDTH: usize = 80;
+const CONSOLE_HEIGHT: usize = 25;
+
+pub static CONSOLE: TicketMutex<Console> = TicketMutex::new(Console {
+    buffer: ConsoleBuffer {
+        chars: [[ConsoleChar {
+            character: '\0',
+            color: 0,
+        }; CONSOLE_WIDTH]; CONSOLE_HEIGHT],
+    },
+    cursor_x: 0,
+    cursor_y: 0,
+});
+
+/// Represents a single character on the framebuffer console
+#[derive(Copy, Clone)]
+struct ConsoleChar {
+    character: char,
+    color: u32,
+}
+
+/// Buffer of characters in the console
+struct ConsoleBuffer {
+    chars: [[ConsoleChar; CONSOLE_WIDTH]; CONSOLE_HEIGHT],
+}
+
+/// Framebuffer console
+pub struct Console {
+    buffer: ConsoleBuffer,
+    cursor_x: usize,
+    cursor_y: usize,
+}
+
+impl Console {
+    /// Create a new console
+    pub fn new() -> Self {
+        Self {
+            buffer: ConsoleBuffer {
+                chars: [[ConsoleChar {
+                    character: '\0',
+                    color: 0,
+                }; CONSOLE_WIDTH]; CONSOLE_HEIGHT],
+            },
+            cursor_x: 0,
+            cursor_y: 0,
+        }
+    }
+
+    /// Write a char to the console
+    pub fn write_char(&mut self, character: char, color: u32) {
+        // Write the character to the buffer
+        match character {
+            // Newline
+            '\n' => {
+                self.cursor_x = 0;
+                self.cursor_y += 1;
+            }
+            // Carriage return
+            '\r' => self.cursor_x = 0,
+            // Tab
+            '\t' => {
+                for i in 0..4 {
+                    self.write_char(' ', color);
+                }
+            }
+            // Backspace
+            '\x08' => {
+                if self.cursor_x > 0 {
+                    self.cursor_x -= 1;
+                    self.write_char(' ', color);
+                    self.cursor_x -= 1;
+                }
+            }
+            // Any other character
+            _ => {
+                self.buffer.chars[self.cursor_y][self.cursor_x] = ConsoleChar {
+                    character,
+                    color,
+                };
+                self.cursor_x += 1;
+            }
+        }
+
+        // If we've reached the end of the line, move to the next line
+        if self.cursor_x >= CONSOLE_WIDTH {
+            self.cursor_x = 0;
+            self.cursor_y += 1;
+        }
+
+        // If we've reached the end of the console, scroll
+        if self.cursor_y >= CONSOLE_HEIGHT {
+            self.scroll();
+        }
+    }
+
+    /// Write a string to the console
+    pub fn write_str(&mut self, string: &str, color: u32) {
+        for character in string.chars() {
+            self.write_char(character, color);
+        }
+        // Flush the console to the framebuffer
+        self.flush();
+    }
+
+    /// Clear the console
+    pub fn clear(&mut self) {
+        for y in 0..CONSOLE_HEIGHT {
+            for x in 0..CONSOLE_WIDTH {
+                self.buffer.chars[y][x] = ConsoleChar {
+                    character: '\0',
+                    color: 0,
+                };
+            }
+        }
+        self.cursor_x = 0;
+        self.cursor_y = 0;
+    }
+
+    /// Scroll the console
+    fn scroll(&mut self) {
+        // Move all lines up by one
+        for y in 1..CONSOLE_HEIGHT {
+            for x in 0..CONSOLE_WIDTH {
+                self.buffer.chars[y - 1][x] = self.buffer.chars[y][x];
+            }
+        }
+
+        // Clear the last line
+        for x in 0..CONSOLE_WIDTH {
+            self.buffer.chars[CONSOLE_HEIGHT - 1][x] = ConsoleChar {
+                character: '\0',
+                color: 0,
+            };
+        }
+        self.cursor_y = CONSOLE_HEIGHT - 1;
+    }
+
+    /// Flush the console to the framebuffer
+    fn flush(&self) {
+        for y in 0..CONSOLE_HEIGHT {
+            for x in 0..CONSOLE_WIDTH {
+                // Draw the character to the framebuffer
+                FRAMEBUFFER.lock().draw_char(
+                    x * FONT_WIDTH + 1, // Add a 1 pixel margin between characters
+                    y * FONT_HEIGHT + 1, // Add a 1 pixel margin between lines
+                    self.buffer.chars[y][x].character,
+                    self.buffer.chars[y][x].color,
+                );
+            }
+        }
+    }
+}
+
+impl fmt::Write for Console {
+    fn write_str(&mut self, string: &str) -> fmt::Result {
+        self.write_str(string, 0xFFFFFFFF);
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {
+        CONSOLE.lock().write_fmt(format_args!($($arg)*)).unwrap();
+    }
+}
+
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => {
+        CONSOLE.lock().write_fmt(format_args!(concat!($($arg,)* "\n"))).unwrap();
+    }
+}

--- a/charlotte_core/src/framebuffer/console.rs
+++ b/charlotte_core/src/framebuffer/console.rs
@@ -6,16 +6,7 @@ use crate::framebuffer::{framebuffer::FRAMEBUFFER, chars::{FONT_HEIGHT, FONT_WID
 const CONSOLE_WIDTH: usize = 80;
 const CONSOLE_HEIGHT: usize = 25;
 
-pub static CONSOLE: TicketMutex<Console> = TicketMutex::new(Console {
-    buffer: ConsoleBuffer {
-        chars: [[ConsoleChar {
-            character: '\0',
-            color: 0,
-        }; CONSOLE_WIDTH]; CONSOLE_HEIGHT],
-    },
-    cursor_x: 0,
-    cursor_y: 0,
-});
+pub static CONSOLE: TicketMutex<Console> = TicketMutex::new(Console::new());
 
 /// Represents a single character on the framebuffer console
 #[derive(Copy, Clone)]
@@ -38,7 +29,7 @@ pub struct Console {
 
 impl Console {
     /// Create a new console
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             buffer: ConsoleBuffer {
                 chars: [[ConsoleChar {

--- a/charlotte_core/src/framebuffer/framebuffer.rs
+++ b/charlotte_core/src/framebuffer/framebuffer.rs
@@ -160,6 +160,8 @@ impl FrameBufferInfo {
             for col in 0..FONT_WIDTH {
                 if (bits >> (FONT_WIDTH - 1 - col)) & 1 == 1 {
                     self.draw_pixel(x + col, y + row, color);
+                } else {
+                    self.draw_pixel(x + col, y + row, 0x00000000);
                 }
             }
         }

--- a/charlotte_core/src/framebuffer/framebuffer.rs
+++ b/charlotte_core/src/framebuffer/framebuffer.rs
@@ -10,7 +10,7 @@ use spin::mutex::TicketMutex;
 
 lazy_static! {
     /// Global access to the framebuffer
-    pub static ref FRAMEBUFFER: TicketMutex<FrameBufferInfo> = TicketMutex::new(init_framebuffer().unwrap());
+    pub static ref FRAMEBUFFER: TicketMutex<FrameBufferInfo> = TicketMutex::new(init_framebuffer().unwrap());    
 }
 
 /// A struct representing the framebuffer information,
@@ -43,7 +43,6 @@ impl FrameBufferInfo {
             height: framebuffer.height() as usize,
             pitch: framebuffer.pitch() as usize,
             bpp: framebuffer.bpp() as usize,
-
         }
     }
 
@@ -138,9 +137,8 @@ impl FrameBufferInfo {
                     x = start_x;
                 }
                 _ => {
-                    let bitmap = get_char_bitmap(c);
                     unsafe {
-                        self.draw_char(x, y, bitmap, color);
+                        self.draw_char(x, y, c, color);
                     }
                     x += FONT_WIDTH;
                 }
@@ -156,7 +154,8 @@ impl FrameBufferInfo {
     /// * `y` - The y coordinate where the character should be drawn.
     /// * `bitmap` - A reference to the bitmap array representing the character.
     /// * `color` - The color of the character in ARGB format.
-    pub fn draw_char(&self, x: usize, y: usize, bitmap: &[u8; FONT_HEIGHT], color: u32) {
+    pub fn draw_char(&self, x: usize, y: usize, chracter: char, color: u32) {
+        let bitmap = get_char_bitmap(chracter);
         for (row, &bits) in bitmap.iter().enumerate() {
             for col in 0..FONT_WIDTH {
                 if (bits >> (FONT_WIDTH - 1 - col)) & 1 == 1 {

--- a/charlotte_core/src/framebuffer/mod.rs
+++ b/charlotte_core/src/framebuffer/mod.rs
@@ -1,3 +1,4 @@
 pub mod framebuffer;
 pub mod chars;
 pub mod colors;
+pub mod console;

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -13,20 +13,17 @@ use core::fmt::Write;
 
 use arch::{Api, ArchApi};
 
-use framebuffer::framebuffer::{FRAMEBUFFER, Point};
+use framebuffer::console::CONSOLE;
+
+use crate::framebuffer::framebuffer::FRAMEBUFFER;
 
 #[no_mangle]
 unsafe extern "C" fn main() -> ! {
     let mut logger = ArchApi::get_logger();
-    
+
     FRAMEBUFFER.lock().clear_screen(0x00000000);
-    FRAMEBUFFER.lock().draw_text(100, 100, " !\"#$%&'()*+,-./",0xFFFFFFF);
-    FRAMEBUFFER.lock().draw_text(100, 116, "0123456789:;<=>?",0xFFFFFFF);
-    FRAMEBUFFER.lock().draw_text(100, 132, "@ABCDEFGHIJKLMNO",0xFFFFFFF);
-    FRAMEBUFFER.lock().draw_text(100, 148, "PQRSTUVWXYZ[\\]^_",0xFFFFFFF);
-    FRAMEBUFFER.lock().draw_text(100, 164, "`abcdefghijklmno",0xFFFFFFF);
-    FRAMEBUFFER.lock().draw_text(100, 180, "pqrstuvwxyz{:}~\t",0xFFFFFFF);
-    
+    println!("Hello, world!");
+
     write!(&mut logger, "Initializing BSP\n").unwrap();
     ArchApi::init_bsp();
     write!(&mut logger, "BSP Initialized\n").unwrap();


### PR DESCRIPTION
Implements logging to the framebuffer as a console.

Supports handling newlines (\n), carraige returns (\r), tab characters (\t), and backspace (\x08). Also features line wrapping and scrolling the console.

Minor changes to the framebuffer draw_char function for cleanliness.

The console also implements `fmt::Write` and the print!` and `println!` macros. 