### PR TITLE
Cleanup Tss struct initialization and Idtr struct implementation

### DIFF
--- a/charlotte_core/src/arch/x86_64/gdt/tss.rs
+++ b/charlotte_core/src/arch/x86_64/gdt/tss.rs
@@ -12,7 +12,7 @@ impl Tss {
     pub fn new(rsp0: u64) -> Self {
         Tss {
             res: 0,
-            rsp0: rsp0,
+            rsp0,
             unused: [0u8; 90],
             iopb: size_of::<Tss>() as u16,
         }

--- a/charlotte_core/src/arch/x86_64/idt/mod.rs
+++ b/charlotte_core/src/arch/x86_64/idt/mod.rs
@@ -93,8 +93,8 @@ struct Idtr {
 impl Idtr {
     fn new(size: u16, base: u64) -> Self {
         Idtr {
-            size: size,
-            base: base,
+            size,
+            base,
         }
     }
 }


### PR DESCRIPTION
This pull request includes cleanup of the Tss struct initialization and Idtr struct implementation. The changes ensure that the rsp0 field is initialized using shorthand syntax and that the size and base fields in the Idtr struct are also initialized using shorthand syntax.

This apeases the compiler to bring down the warning counts.