### PR TITLE
Remove `lazy_static` dependency

### DIFF
--- a/charlotte_core/Cargo.lock
+++ b/charlotte_core/Cargo.lock
@@ -29,9 +29,8 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "ignore-result",
- "lazy_static",
  "limine",
- "spin 0.9.8",
+ "spin",
  "walkdir",
 ]
 
@@ -40,15 +39,6 @@ name = "ignore-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "665ff4dce8edd10d490641ccb78949832f1ddbff02c584fb1f85ab888fe0e50c"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
 
 [[package]]
 name = "libc"
@@ -89,12 +79,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"

--- a/charlotte_core/Cargo.toml
+++ b/charlotte_core/Cargo.toml
@@ -15,6 +15,5 @@ walkdir = "*"
 
 [dependencies]
 ignore-result = "*"
-lazy_static = {version = "*", features = ["spin_no_std"]}
 limine = "0.2.0"
 spin = {version = "*", features = ["ticket_mutex"]}

--- a/charlotte_core/src/arch/x86_64/idt/mod.rs
+++ b/charlotte_core/src/arch/x86_64/idt/mod.rs
@@ -7,7 +7,7 @@ pub struct Idt {
 }
 
 impl Idt {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Idt {
             gates: [InterruptGate::new(); 256],
         }

--- a/charlotte_core/src/arch/x86_64/memory/mod.rs
+++ b/charlotte_core/src/arch/x86_64/memory/mod.rs
@@ -7,21 +7,20 @@ pub mod pmm;
 mod vmm;
 
 use core::arch::x86_64::__cpuid_count;
-use lazy_static::lazy_static;
+use spin::lazy::Lazy;
 
-lazy_static! {
-    ///The number of significant bits in a physical address on the current CPU.
-    pub static ref PADDR_SIG_BITS: u8 = {
-        let cpuid = unsafe { __cpuid_count(0x80000008, 0) };
-        // 0x80000008 is the highest cpuid leaf that returns the physical address width in EAX[7:0]
-        let psig_bits = cpuid.eax & 0xFF;
-        psig_bits as u8
-    };
-    ///The number of significant bits in a virtual address on the current CPU.
-    pub static ref VADDR_SIG_BITS: u8 = {
-        let cpuid = unsafe { __cpuid_count(0x80000008, 0) };
-        // 0x80000008 is the highest cpuid leaf that returns the virtual address width in EAX[15:8]
-        let vsig_bits = (cpuid.eax >> 8) & 0xFF;
-        vsig_bits as u8
-    };
-}
+/// The number of significant bits in a physical address on the current CPU.
+pub static PADDR_SIG_BITS: Lazy<u8> = Lazy::new(|| {
+    let cpuid = unsafe { __cpuid_count(0x80000008, 0) };
+    // 0x80000008 is the highest cpuid leaf that returns the physical address width in EAX[7:0]
+    let psig_bits = cpuid.eax & 0xFF;
+    psig_bits as u8
+});
+
+/// The number of significant bits in a virtual address on the current CPU.
+pub static VADDR_SIG_BITS: Lazy<u8> = Lazy::new(|| {
+    let cpuid = unsafe { __cpuid_count(0x80000008, 0) };
+    // 0x80000008 is the highest cpuid leaf that returns the virtual address width in EAX[15:8]
+    let vsig_bits = (cpuid.eax >> 8) & 0xFF;
+    vsig_bits as u8
+});

--- a/charlotte_core/src/framebuffer/framebuffer.rs
+++ b/charlotte_core/src/framebuffer/framebuffer.rs
@@ -4,14 +4,13 @@ use crate::bootinfo::FRAMEBUFFER_REQUEST;
 use crate::framebuffer::chars::{get_char_bitmap, FONT_HEIGHT, FONT_WIDTH};
 // External crate for bootloader-specific functions and types.
 extern crate limine;
-use lazy_static::lazy_static;
 use limine::framebuffer::Framebuffer;
+use spin::lazy::Lazy;
 use spin::mutex::TicketMutex;
 
-lazy_static! {
-    /// Global access to the framebuffer
-    pub static ref FRAMEBUFFER: TicketMutex<FrameBufferInfo> = TicketMutex::new(init_framebuffer().unwrap());
-}
+/// Global access to the framebuffer
+pub static FRAMEBUFFER: Lazy<TicketMutex<FrameBufferInfo>> =
+    Lazy::new(|| TicketMutex::new(init_framebuffer().unwrap()));
 
 /// A struct representing the framebuffer information,
 /// including its memory address, dimensions, pixel format, etc.


### PR DESCRIPTION
Replace all uses of `lazy_static` with the `Lazy` type in the `spin` crate. While we are at it, make a few statics non-lazy if not needed, like `BSP_RING0_INT_STACK` and `BSP_IDT`.

Fixes: #34 