### PR TITLE
Add logger for both serial and console

### DIFF
--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -21,36 +21,25 @@ unsafe extern "C" fn main() -> ! {
     FRAMEBUFFER.lock().clear_screen(0x00000000);
     println!("Hello, world!");
 
-    write!(&mut logger, "Initializing BSP\n").unwrap();
+    logln!("Initializing BSP");
     ArchApi::init_bsp();
-    write!(&mut logger, "BSP Initialized\n").unwrap();
+    logln!("BSP Initialized");
 
-    write!(&mut logger, "All tests in main passed.\n").unwrap();
+    logln!("All tests in main passed.");
 
-    writeln!(
-        &mut logger,
-        "Number of Significant Physical Address Bits Supported: {}",
-        ArchApi::get_paddr_width()
-    )
-    .unwrap();
+    logln!("Number of Significant Physical Address Bits Supported: {}", ArchApi::get_paddr_width());
+    logln!("Number of Significant Virtual Address Bits Supported: {}", ArchApi::get_vaddr_width());
 
-    writeln!(
-        &mut logger,
-        "Number of Significant Virtual Address Bits Supported: {}",
-        ArchApi::get_vaddr_width()
-    )
-    .unwrap();
-
-    writeln!(&mut logger, "Testing physical frame allocator").unwrap();
+    logln!("Testing physical frame allocator");
     let mut pfa = PFA.lock();
     match pfa.allocate_frames(50, None) {
         Ok(region_descriptor) => {
-            writeln!(&mut logger, "Allocated region: {:?}", region_descriptor).unwrap();
+            logln!("Allocated region: {:?}", region_descriptor);
             let _ = pfa.deallocate_frames(region_descriptor);
-            writeln!(&mut logger, "Deallocated previously allocated region.").unwrap();
+            logln!("Deallocated previously allocated region.");
         }
         Err(e) => {
-            writeln!(&mut logger, "Failed to allocate region with error {:?}", e).unwrap();
+            logln!("Failed to allocate region with error {:?}", e);
         }
     }
     ArchApi::halt()
@@ -58,15 +47,7 @@ unsafe extern "C" fn main() -> ! {
 
 #[panic_handler]
 fn rust_panic(_info: &core::panic::PanicInfo) -> ! {
-    ArchApi::get_logger()
-        .write_fmt(format_args!(
-            "A kernel panic has occurred due to a Rust runtime panic.\n PanicInfo: {:?}\n",
-            _info
-        ))
-        .unwrap();
-    println!(
-        "A kernel panic has occurred due to a Rust runtime panic.\n PanicInfo: {:?}\n",
-        _info
-    );
+    logln!("A kernel panic has occurred due to a Rust runtime panic.");
+    logln!("PanicInfo: {:?}", _info);
     ArchApi::panic()
 }


### PR DESCRIPTION
- Adds a logger struct that can log to both the serial port and framebuffer console to ease debugging.
- Adds `log!` and `logln!` macros that write to both the serial port and framebuffer.
![image](https://github.com/charlotte-os/CharlotteCore/assets/9831482/6d59ac76-5c49-48d0-b557-522b27072d69)
