### PR TITLE
pmm: improve `PhysicalFrameAllocator` performance and other improvements

### DIFF
--- a/charlotte_core/src/arch/x86_64/memory/pmm.rs
+++ b/charlotte_core/src/arch/x86_64/memory/pmm.rs
@@ -288,6 +288,10 @@ impl PhysicalFrameAllocator {
             //find the next non-null region
             next_nonnull_index = i + 1;
 
+            if region_array[i].region_type == PhysicalMemoryType::PfaNull {
+                continue;
+            }
+
             while next_nonnull_index < region_array.len()
                 && region_array[next_nonnull_index].region_type == PhysicalMemoryType::PfaNull
             {
@@ -300,7 +304,6 @@ impl PhysicalFrameAllocator {
 
             //if the current region and the next region are of the same type, not null, and adjacent, merge them
             if region_array[i].region_type == region_array[next_nonnull_index].region_type
-                && region_array[i].region_type != PhysicalMemoryType::PfaNull
                 && region_array[i].base + region_array[i].n_frames * FRAME_SIZE
                     == region_array[next_nonnull_index].base
             {

--- a/charlotte_core/src/arch/x86_64/memory/pmm.rs
+++ b/charlotte_core/src/arch/x86_64/memory/pmm.rs
@@ -43,7 +43,7 @@ static UNALLOCATED_FRAMES_COMMITTED: AtomicUsize = AtomicUsize::new(0);
 /// When the system is overcommitted by more than this percentage, new allocations will fail.
 const REQUIRED_COMMIT_BACKING_PERCENTAGE: usize = 70;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[allow(unused)]
 pub enum Error {
     InsufficientMemory,
@@ -82,7 +82,7 @@ pub fn uncommit_frames(n_frames: usize) -> Result<(), Error> {
 /// It is identical to the defines used by Limine with the exception of PfaReserved, which is used to represent
 /// regions of physical memory that are reserved for use by the PFA itself and PfaNull, which is used to represent
 /// region descriptors that are not in use.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Copy)]
 pub enum PhysicalMemoryType {
     Usable,
     Reserved,
@@ -100,7 +100,7 @@ pub enum PhysicalMemoryType {
 /// A physical memory region descriptor. This struct is used to represent a region of physical memory in the
 /// physical memory region array. It contains the base address of the region, the number of frames in the region,
 /// the type of the region, and optionally a capability capability that is used to access the region.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Copy)]
 pub struct PhysicalMemoryRegion {
     capability: Option<CapabilityId>,
     base: usize,
@@ -143,7 +143,7 @@ impl Ord for PhysicalMemoryRegion {
 }
 
 /// The physical frame allocator is responsible for managing and allocating physical memory frames.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct PhysicalFrameAllocator {
     region_array_base: usize, // physical base address of the array of physical memory regions
     region_array_len: usize,  // number of elements in the array of physical memory regions
@@ -358,7 +358,7 @@ impl PhysicalFrameAllocator {
         };
         smallest_usable_region.base += n_frames * FRAME_SIZE;
         smallest_usable_region.n_frames -= n_frames;
-        Self::append_region(region_array, allocated_region.clone())?;
+        Self::append_region(region_array, allocated_region)?;
         Ok(allocated_region)
     }
 

--- a/charlotte_core/src/arch/x86_64/mod.rs
+++ b/charlotte_core/src/arch/x86_64/mod.rs
@@ -74,8 +74,6 @@ impl crate::arch::Api for Api {
     fn init_bsp() {
         //! This routine is run by the bootsrap processor to initilize itself priot to bringing up the kernel.
 
-        let mut logger = SerialPort::try_new(ComPort::COM1).unwrap();
-
         logln!("Initializing the bootstrap processor...");
 
         BSP_GDT.load();

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -16,8 +16,6 @@ use crate::framebuffer::framebuffer::FRAMEBUFFER;
 
 #[no_mangle]
 unsafe extern "C" fn main() -> ! {
-    let mut logger = ArchApi::get_logger();
-
     FRAMEBUFFER.lock().clear_screen(0x00000000);
     println!("Hello, world!");
 

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![warn(missing_copy_implementations)]
 
 mod arch;
 mod bootinfo;


### PR DESCRIPTION
Several code cleanups and a severe performance improvement for the `PhysicalFrameAllocator`. The issue was that `PhysicalFrameAllocator::merge_and_sort_region_array()` was attempting to find merge candidates for null memory regions (`PfaNull`). This resulted in heavy O(n^2) behavior since, for every region, it was traversing a good part of the region array, only to discard the result, as null regions are not merged.

This should fix or at least mitigate #53.