### PR TITLE
Request RSDP info from Limine

### DIFF
--- a/charlotte_core/src/acpi/mod.rs
+++ b/charlotte_core/src/acpi/mod.rs
@@ -1,0 +1,13 @@
+//! # ACPI Information
+//! This module contains requests for information from the ACPI tables.
+
+use crate::{bootinfo::RSDP_REQUEST, logln};
+use core::fmt::Write;
+
+pub fn init_acpi() {
+    if let Some(response) = RSDP_REQUEST.get_response() {
+        logln!("RSDP Address: {:x}", response.address() as usize);
+    } else {
+        panic!("Failed to obtain RSDP response.");
+    }
+}

--- a/charlotte_core/src/bootinfo/mod.rs
+++ b/charlotte_core/src/bootinfo/mod.rs
@@ -16,3 +16,6 @@ pub static MEMORY_MAP_REQUEST: MemoryMapRequest = MemoryMapRequest::new();
 
 /// This request is used to obtain the framebuffer
 pub static FRAMEBUFFER_REQUEST: FramebufferRequest = FramebufferRequest::new();
+
+/// This request is used to obtain RSDP data
+pub static RSDP_REQUEST: RsdpRequest = RsdpRequest::new();

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![warn(missing_copy_implementations)]
 
+mod acpi;
 mod arch;
 mod bootinfo;
 mod framebuffer;
@@ -24,6 +25,10 @@ unsafe extern "C" fn main() -> ! {
     ArchApi::init_bsp();
     logln!("BSP Initialized");
 
+    logln!("Initializing ACPI");
+    acpi::init_acpi();
+    logln!("ACPI Initialized");
+
     logln!("All tests in main passed.");
 
     logln!("Number of Significant Physical Address Bits Supported: {}", ArchApi::get_paddr_width());
@@ -41,6 +46,7 @@ unsafe extern "C" fn main() -> ! {
             logln!("Failed to allocate region with error {:?}", e);
         }
     }
+
     ArchApi::halt()
 }
 


### PR DESCRIPTION
Part of #55 

Requests the memory address of the RDSP from Limine and logs it. Also creates a stub ACPI module to hold the code for the ACPI table parsers. 

![image](https://github.com/charlotte-os/CharlotteCore/assets/9831482/781b5426-c922-4b69-80d5-b05d78ed761d)
