### PR TITLE
Load the MADT and Parse APIC entries

### DIFF
--- a/charlotte_core/src/acpi/madt.rs
+++ b/charlotte_core/src/acpi/madt.rs
@@ -8,6 +8,7 @@ pub struct Madt {
     header: SDTHeader,
     local_apic_addr: u32,
     flags: u32,
+    addr: usize,
 }
 
 impl Madt {
@@ -20,6 +21,7 @@ impl Madt {
                 header,
                 local_apic_addr,
                 flags,
+                addr,
             }
         } else {
             panic!("Failed to validate MADT");
@@ -33,4 +35,132 @@ impl Madt {
     pub fn flags(&self) -> u32 {
         self.flags
     }
+
+    pub fn iter(&self) -> MadtIter {
+        MadtIter {
+            addr: self.addr + mem::size_of::<SDTHeader>() + 8, // Skip over the header, the local APIC address and flags
+            offset: 0,
+            len: self.header.length() as usize,
+        }
+    }
+}
+
+/// MADT Entry Iterator
+pub struct MadtIter {
+    addr: usize,
+    offset: usize,
+    len: usize,
+}
+
+impl Iterator for MadtIter {
+    type Item = MadtEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset < self.len {
+            let header = unsafe { &*((self.addr + self.offset) as *const MadtEntryHeader) };
+            let entry = match header.entry_type {
+                0 => MadtEntry::ProcessorLocalApic(unsafe {
+                    *((self.addr + self.offset) as *const ProcessorLocalApic)
+                }),
+                1 => MadtEntry::IOApic(unsafe { *((self.addr + self.offset) as *const IoApic) }),
+                2 => MadtEntry::InterruptSourceOverride(unsafe {
+                    *((self.addr + self.offset) as *const InterruptSourceOverride)
+                }),
+                3 => MadtEntry::NonMaskableInterruptSource(unsafe {
+                    *((self.addr + self.offset) as *const NonMaskableInterruptSource)
+                }),
+                4 => MadtEntry::LocalApicNmi(unsafe {
+                    *((self.addr + self.offset) as *const LocalApicNmi)
+                }),
+                5 => MadtEntry::LocalApicAddressOverride(unsafe {
+                    *((self.addr + self.offset) as *const LocalApicAddressOverride)
+                }),
+                _ => MadtEntry::Unknown(header.entry_type),
+            };
+            self.offset += header.length as usize;
+            Some(entry)
+        } else {
+            None
+        }
+    }
+}
+
+/// MADT Entries
+#[derive(Debug)]
+pub enum MadtEntry {
+    ProcessorLocalApic(ProcessorLocalApic),
+    IOApic(IoApic),
+    InterruptSourceOverride(InterruptSourceOverride),
+    NonMaskableInterruptSource(NonMaskableInterruptSource),
+    LocalApicNmi(LocalApicNmi),
+    LocalApicAddressOverride(LocalApicAddressOverride),
+    Unknown(u8),
+}
+
+/// MADT Entry Header
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug)]
+struct MadtEntryHeader {
+    entry_type: u8,
+    length: u8,
+}
+
+/// Processor Local APIC Structure
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct ProcessorLocalApic {
+    header: MadtEntryHeader,
+    processor_id: u8,
+    apic_id: u8,
+    flags: u32,
+}
+
+/// IO APIC Structure
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct IoApic {
+    header: MadtEntryHeader,
+    io_apic_id: u8,
+    reserved: u8,
+    io_apic_addr: u32,
+    global_system_interrupt_base: u32,
+}
+
+/// Interrupt Source Override Structure
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct InterruptSourceOverride {
+    header: MadtEntryHeader,
+    bus: u8,
+    source: u8,
+    global_system_interrupt: u32,
+    flags: u16,
+}
+
+/// Non-maskable Interrupt Source Structure
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct NonMaskableInterruptSource {
+    header: MadtEntryHeader,
+    flags: u16,
+    global_system_interrupt: u32,
+}
+
+/// Local APIC NMI Structure
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct LocalApicNmi {
+    header: MadtEntryHeader,
+    processor_id: u8,
+    flags: u16,
+    local_apic_lint: u8,
+}
+
+/// Local APIC Address Override Structure
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct LocalApicAddressOverride {
+    header: MadtEntryHeader,
+    reserved: u16,
+    local_apic_address: u64,
 }

--- a/charlotte_core/src/acpi/madt.rs
+++ b/charlotte_core/src/acpi/madt.rs
@@ -1,0 +1,36 @@
+//! MADT Parsing facilities
+use core::mem;
+
+use crate::acpi::tables::{get_table, SDTHeader};
+
+/// The MADT
+pub struct Madt {
+    header: SDTHeader,
+    local_apic_addr: u32,
+    flags: u32,
+}
+
+impl Madt {
+    pub fn new(addr: usize) -> Madt {
+        let header = get_table(addr, *b"APIC");
+        if let Some(header) = header {
+            let local_apic_addr = unsafe { *((addr + mem::size_of::<SDTHeader>()) as *const u32) };
+            let flags = unsafe { *((addr + mem::size_of::<SDTHeader>() + 4) as *const u32) };
+            Madt {
+                header,
+                local_apic_addr,
+                flags,
+            }
+        } else {
+            panic!("Failed to validate MADT");
+        }
+    }
+
+    pub fn local_apic_addr(&self) -> u32 {
+        self.local_apic_addr
+    }
+
+    pub fn flags(&self) -> u32 {
+        self.flags
+    }
+}

--- a/charlotte_core/src/acpi/mod.rs
+++ b/charlotte_core/src/acpi/mod.rs
@@ -1,6 +1,7 @@
 //! # ACPI Information
 //! This module contains requests for information from the ACPI tables.
 
+mod madt;
 mod rsdp;
 mod sdt;
 pub mod tables;
@@ -10,18 +11,20 @@ use core::fmt::Write;
 
 use crate::acpi::rsdp::Rsdp;
 
+use self::madt::Madt;
 use self::sdt::Sdt;
 
 /// Stores the data for all the ACPI tables.
 pub struct AcpiTables {
     rsdp: Rsdp,
     sdt: sdt::Sdt,
+    madt: Madt,
 }
 
 impl AcpiTables {
     /// Creates a new AcpiTables.
-    pub fn new(rsdp: Rsdp, sdt: Sdt) -> Self {
-        Self { rsdp, sdt }
+    pub fn new(rsdp: Rsdp, sdt: Sdt, madt: Madt) -> Self {
+        Self { rsdp, sdt, madt }
     }
 
     pub fn rsdp(&self) -> &Rsdp {
@@ -56,7 +59,9 @@ pub fn init_acpi() -> AcpiTables {
         logln!("SDT Revision: {}", sdt.header().revision());
         logln!("SDT entry count: {}", sdt.n_entries());
         logln!("SDT address width: {}", sdt.addr_width());
-        AcpiTables::new(rsdp, sdt)
+        let madt = Madt::new(sdt.get_table(*b"APIC").unwrap());
+        logln!("MADT Local APIC Address: {:#X}", madt.local_apic_addr());
+        AcpiTables::new(rsdp, sdt, madt)
     } else {
         panic!("Failed to obtain RSDP response.");
     }

--- a/charlotte_core/src/acpi/mod.rs
+++ b/charlotte_core/src/acpi/mod.rs
@@ -34,6 +34,10 @@ impl AcpiTables {
     pub fn sdt(&self) -> &Sdt {
         &self.sdt
     }
+
+    pub fn madt(&self) -> &Madt {
+        &self.madt
+    }
 }
 
 pub fn init_acpi() -> AcpiTables {
@@ -61,6 +65,9 @@ pub fn init_acpi() -> AcpiTables {
         logln!("SDT address width: {}", sdt.addr_width());
         let madt = Madt::new(sdt.get_table(*b"APIC").unwrap());
         logln!("MADT Local APIC Address: {:#X}", madt.local_apic_addr());
+        for entry in madt.iter() {
+            logln!("MADT Entry: {:?}", entry);
+        }
         AcpiTables::new(rsdp, sdt, madt)
     } else {
         panic!("Failed to obtain RSDP response.");


### PR DESCRIPTION
Part of #55

This loads the Multiple APIC Description Table (MADT) from the ACPI tables, and parses the entries corresponding to the Advanced Programmable Interrupt Controller (APIC). 

![image](https://github.com/charlotte-os/CharlotteCore/assets/9831482/a9b142dd-c41e-4e8e-8d71-9971291e709a)


Specifically it parses the following MADT entry types:

0x00: Processor Local APIC
0x01: I/O APIC
0x02: Interrupt Source Override
0x03: Non-maskable Interrupt (NMI) Source
0x04: Local APIC NMI
0x05: Local APIC Address Override

While we'll still need to parse the entries corresponding to the x2APIC, and Generic Interrupt Controller (GIC) for ARM devices, this should be most of what's needed to start unblocking #24. 