### PR TITLE
Issue #52 improve color support

### DIFF
--- a/charlotte_core/src/framebuffer/colors.rs
+++ b/charlotte_core/src/framebuffer/colors.rs
@@ -4,14 +4,14 @@
 pub struct Color;
 
 impl Color {
-    pub const BLACK:   u32 = 0x00000000;
-    pub const WHITE:   u32 = 0xFFFFFFFF;
-    pub const RED:     u32 = 0x00FF0000;
-    pub const GREEN:   u32 = 0x0000FF00;
-    pub const BLUE:    u32 = 0x000000FF;
-    pub const YELLOW:  u32 = 0x00FFFF00;
+    pub const BLACK: u32 = 0x00000000;
+    pub const WHITE: u32 = 0xFFFFFFFF;
+    pub const RED: u32 = 0x00FF0000;
+    pub const GREEN: u32 = 0x0000FF00;
+    pub const BLUE: u32 = 0x000000FF;
+    pub const YELLOW: u32 = 0x00FFFF00;
     pub const MAGENTA: u32 = 0x00FF00FF;
-    pub const CYAN:    u32 = 0x0000FFFF;
+    pub const CYAN: u32 = 0x0000FFFF;
 }
 
 #[allow(unused)]

--- a/charlotte_core/src/framebuffer/colors.rs
+++ b/charlotte_core/src/framebuffer/colors.rs
@@ -4,14 +4,14 @@
 pub struct Color;
 
 impl Color {
-    pub const BLACK:  u32 = 0x00000000;
-    pub const WHITE:  u32 = 0xFFFFFFFF;
-    pub const RED:    u32 = 0x00FF0000;
-    pub const GREEN:  u32 = 0x0000FF00;
-    pub const BLUE:   u32 = 0x000000FF;
-    pub const YELLOW: u32 = 0x00FFFF00;
-    pub const PURPLE: u32 = 0x00FF00FF;
-    pub const CYAN:   u32 = 0x0000FFFF;
+    pub const BLACK:   u32 = 0x00000000;
+    pub const WHITE:   u32 = 0xFFFFFFFF;
+    pub const RED:     u32 = 0x00FF0000;
+    pub const GREEN:   u32 = 0x0000FF00;
+    pub const BLUE:    u32 = 0x000000FF;
+    pub const YELLOW:  u32 = 0x00FFFF00;
+    pub const MAGENTA: u32 = 0x00FF00FF;
+    pub const CYAN:    u32 = 0x0000FFFF;
 }
 
 #[allow(unused)]

--- a/charlotte_core/src/framebuffer/colors.rs
+++ b/charlotte_core/src/framebuffer/colors.rs
@@ -1,3 +1,19 @@
+/// Define as a non_exhaustive struct to behave as an "enum" with constant values
+/// Doing it this way avoids explicit type casting with Rust enums
+#[non_exhaustive]
+pub struct Color;
+
+impl Color {
+    pub const BLACK:  u32 = 0x00000000;
+    pub const WHITE:  u32 = 0xFFFFFFFF;
+    pub const RED:    u32 = 0x00FF0000;
+    pub const GREEN:  u32 = 0x0000FF00;
+    pub const BLUE:   u32 = 0x000000FF;
+    pub const YELLOW: u32 = 0x00FFFF00;
+    pub const PURPLE: u32 = 0x00FF00FF;
+    pub const CYAN:   u32 = 0x0000FFFF;
+}
+
 #[allow(unused)]
 pub fn blend_colors(foreground: u32, background: u32, blend_factor: u8) -> u32 {
     let fg_ratio = blend_factor as u32;

--- a/charlotte_core/src/framebuffer/console.rs
+++ b/charlotte_core/src/framebuffer/console.rs
@@ -3,6 +3,7 @@ use spin::mutex::TicketMutex;
 
 use crate::framebuffer::{
     chars::{FONT_HEIGHT, FONT_WIDTH},
+    colors::Color,
     framebuffer::FRAMEBUFFER,
 };
 
@@ -16,6 +17,7 @@ pub static CONSOLE: TicketMutex<Console> = TicketMutex::new(Console::new());
 struct ConsoleChar {
     character: char,
     color: u32,
+    background_color: u32,
 }
 
 /// Buffer of characters in the console
@@ -28,6 +30,8 @@ pub struct Console {
     buffer: ConsoleBuffer,
     cursor_x: usize,
     cursor_y: usize,
+    text_color: u32,
+    background_color: u32,
 }
 
 #[allow(unused)]
@@ -39,15 +43,23 @@ impl Console {
                 chars: [[ConsoleChar {
                     character: '\0',
                     color: 0,
+                    background_color: 0,
                 }; CONSOLE_WIDTH]; CONSOLE_HEIGHT],
             },
             cursor_x: 0,
             cursor_y: 0,
+            text_color: Color::WHITE,
+            background_color: Color::BLACK,
         }
     }
 
+    pub fn set_colors(&mut self, text_color: u32, background_color: u32) {
+        self.text_color = text_color;
+        self.background_color = background_color;
+    }
+
     /// Write a char to the console
-    pub fn write_char(&mut self, character: char, color: u32) {
+    pub fn write_char(&mut self, character: char, color: Option<u32>, background_color: Option<u32>) {
         // Write the character to the buffer
         match character {
             // Newline
@@ -60,20 +72,20 @@ impl Console {
             // Tab
             '\t' => {
                 for _ in 0..4 {
-                    self.write_char(' ', color);
+                    self.write_char(' ', color, background_color);
                 }
             }
             // Backspace
             '\x08' => {
                 if self.cursor_x > 0 {
                     self.cursor_x -= 1;
-                    self.write_char(' ', color);
+                    self.write_char(' ', color, background_color);
                     self.cursor_x -= 1;
                 }
             }
             // Any other character
             _ => {
-                self.buffer.chars[self.cursor_y][self.cursor_x] = ConsoleChar { character, color };
+                self.buffer.chars[self.cursor_y][self.cursor_x] = ConsoleChar { character, color: color.unwrap_or(self.text_color), background_color: background_color.unwrap_or(self.background_color) };
                 self.cursor_x += 1;
             }
         }
@@ -91,9 +103,9 @@ impl Console {
     }
 
     /// Write a string to the console
-    pub fn write_str(&mut self, string: &str, color: u32) {
+    pub fn write_str(&mut self, string: &str, color: Option<u32>, background_color: Option<u32>) {
         for character in string.chars() {
-            self.write_char(character, color);
+            self.write_char(character, color, background_color);
         }
         // Flush the console to the framebuffer
         self.flush();
@@ -106,6 +118,7 @@ impl Console {
                 self.buffer.chars[y][x] = ConsoleChar {
                     character: '\0',
                     color: 0,
+                    background_color: 0,
                 };
             }
         }
@@ -127,6 +140,7 @@ impl Console {
             self.buffer.chars[CONSOLE_HEIGHT - 1][x] = ConsoleChar {
                 character: '\0',
                 color: 0,
+                background_color: 0,
             };
         }
         self.cursor_y = CONSOLE_HEIGHT - 1;
@@ -142,15 +156,84 @@ impl Console {
                     y * FONT_HEIGHT + 1, // Add a 1 pixel margin between lines
                     self.buffer.chars[y][x].character,
                     self.buffer.chars[y][x].color,
+                    self.buffer.chars[y][x].background_color,
                 );
             }
         }
+    }
+
+    pub fn clear_inner_styling(&self) {
+        INNER_STYLE_SETTINGS.lock().clear();
+    }
+}
+
+static INNER_STYLE_SETTINGS: TicketMutex<InnerPrintStyle> = TicketMutex::new(InnerPrintStyle::new());
+
+/// Inner style settings for print macros
+struct InnerPrintStyle {
+    text_color: Option<u32>,
+    background_color: Option<u32>,
+    setting_text_color: bool,
+    setting_background_color: bool,
+}
+
+impl InnerPrintStyle {
+    /// Create a 
+    const fn new() -> Self {
+        Self {
+            text_color: None,
+            background_color: None,
+            setting_text_color: false,
+            setting_background_color: false,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.text_color = None;
+        self.background_color = None;
+        self.setting_text_color = false;
+        self.setting_background_color = false;
     }
 }
 
 impl fmt::Write for Console {
     fn write_str(&mut self, string: &str) -> fmt::Result {
-        self.write_str(string, 0xFFFFFFFF);
+        let mut reading_color_type = false;
+        let mut styling = INNER_STYLE_SETTINGS.lock();
+        
+        if styling.setting_text_color {
+            styling.text_color = Some(u32::from_str_radix(string, 16).unwrap_or(Color::WHITE));
+            styling.setting_text_color = false;
+            return Ok(());
+        }
+        if styling.setting_background_color {
+            styling.background_color = Some(u32::from_str_radix(string, 16).unwrap_or(Color::BLACK));
+            styling.setting_background_color = false;
+            return Ok(());
+        }
+
+        for character in string.chars() {
+            if character == '[' {
+                reading_color_type = true;
+                continue;
+            }
+            if reading_color_type {
+                if character == 'b' || character == 'B' {
+                    styling.setting_text_color = false;
+                    styling.setting_background_color = true;
+                }
+                else if character == 'f' || character == 'F' {
+                    styling.setting_text_color = true;
+                    styling.setting_background_color = false;
+                    
+                }
+                reading_color_type = false;
+                continue;
+            }
+            self.write_char(character, styling.text_color, styling.background_color);
+        }
+        // Flush the console to the framebuffer
+        self.flush();
         Ok(())
     }
 }
@@ -159,6 +242,7 @@ impl fmt::Write for Console {
 macro_rules! print {
     ($($arg:tt)*) => {
         CONSOLE.lock().write_fmt(format_args!($($arg)*)).unwrap();
+        CONSOLE.lock().clear_inner_styling();
     }
 }
 
@@ -166,6 +250,7 @@ macro_rules! print {
 macro_rules! println {
     ($($arg:tt)*) => {
         CONSOLE.lock().write_fmt(format_args!($($arg)*)).unwrap();
-        CONSOLE.lock().write_char('\n', 0xFFFFFFFF);
+        CONSOLE.lock().write_char('\n', None, None);
+        CONSOLE.lock().clear_inner_styling();
     }
 }

--- a/charlotte_core/src/framebuffer/console.rs
+++ b/charlotte_core/src/framebuffer/console.rs
@@ -59,7 +59,12 @@ impl Console {
     }
 
     /// Write a char to the console
-    pub fn write_char(&mut self, character: char, color: Option<u32>, background_color: Option<u32>) {
+    pub fn write_char(
+        &mut self,
+        character: char,
+        color: Option<u32>,
+        background_color: Option<u32>,
+    ) {
         // Write the character to the buffer
         match character {
             // Newline
@@ -85,7 +90,11 @@ impl Console {
             }
             // Any other character
             _ => {
-                self.buffer.chars[self.cursor_y][self.cursor_x] = ConsoleChar { character, color: color.unwrap_or(self.text_color), background_color: background_color.unwrap_or(self.background_color) };
+                self.buffer.chars[self.cursor_y][self.cursor_x] = ConsoleChar {
+                    character,
+                    color: color.unwrap_or(self.text_color),
+                    background_color: background_color.unwrap_or(self.background_color),
+                };
                 self.cursor_x += 1;
             }
         }
@@ -167,7 +176,8 @@ impl Console {
     }
 }
 
-static INNER_STYLE_SETTINGS: TicketMutex<InnerPrintStyle> = TicketMutex::new(InnerPrintStyle::new());
+static INNER_STYLE_SETTINGS: TicketMutex<InnerPrintStyle> =
+    TicketMutex::new(InnerPrintStyle::new());
 
 /// Inner style settings for print macros
 struct InnerPrintStyle {
@@ -178,7 +188,7 @@ struct InnerPrintStyle {
 }
 
 impl InnerPrintStyle {
-    /// Create a 
+    /// Create a
     const fn new() -> Self {
         Self {
             text_color: None,
@@ -200,14 +210,15 @@ impl fmt::Write for Console {
     fn write_str(&mut self, string: &str) -> fmt::Result {
         let mut reading_color_type = false;
         let mut styling = INNER_STYLE_SETTINGS.lock();
-        
+
         if styling.setting_text_color {
             styling.text_color = Some(u32::from_str_radix(string, 16).unwrap_or(Color::WHITE));
             styling.setting_text_color = false;
             return Ok(());
         }
         if styling.setting_background_color {
-            styling.background_color = Some(u32::from_str_radix(string, 16).unwrap_or(Color::BLACK));
+            styling.background_color =
+                Some(u32::from_str_radix(string, 16).unwrap_or(Color::BLACK));
             styling.setting_background_color = false;
             return Ok(());
         }
@@ -221,11 +232,9 @@ impl fmt::Write for Console {
                 if character == 'b' || character == 'B' {
                     styling.setting_text_color = false;
                     styling.setting_background_color = true;
-                }
-                else if character == 'f' || character == 'F' {
+                } else if character == 'f' || character == 'F' {
                     styling.setting_text_color = true;
                     styling.setting_background_color = false;
-                    
                 }
                 reading_color_type = false;
                 continue;

--- a/charlotte_core/src/framebuffer/framebuffer.rs
+++ b/charlotte_core/src/framebuffer/framebuffer.rs
@@ -127,7 +127,7 @@ impl FrameBufferInfo {
     /// * `text` - The text to draw.
     /// * `color` - The color of the text in ARGB format.
 
-    pub fn draw_text(&self, mut x: usize, mut y: usize, text: &str, color: u32) {
+    pub fn draw_text(&self, mut x: usize, mut y: usize, text: &str, color: u32, background_color: u32) {
         let start_x = x; // Remember the starting x position to reset to it on new lines
         for c in text.chars() {
             match c {
@@ -136,7 +136,7 @@ impl FrameBufferInfo {
                     x = start_x;
                 }
                 _ => {
-                    self.draw_char(x, y, c, color);
+                    self.draw_char(x, y, c, color, background_color);
                     x += FONT_WIDTH;
                 }
             }
@@ -151,14 +151,14 @@ impl FrameBufferInfo {
     /// * `y` - The y coordinate where the character should be drawn.
     /// * `bitmap` - A reference to the bitmap array representing the character.
     /// * `color` - The color of the character in ARGB format.
-    pub fn draw_char(&self, x: usize, y: usize, chracter: char, color: u32) {
+    pub fn draw_char(&self, x: usize, y: usize, chracter: char, color: u32, background_color: u32) {
         let bitmap = get_char_bitmap(chracter);
         for (row, &bits) in bitmap.iter().enumerate() {
             for col in 0..FONT_WIDTH {
                 if (bits >> (FONT_WIDTH - 1 - col)) & 1 == 1 {
                     self.draw_pixel(x + col, y + row, color);
                 } else {
-                    self.draw_pixel(x + col, y + row, 0x00000000);
+                    self.draw_pixel(x + col, y + row, background_color);
                 }
             }
         }

--- a/charlotte_core/src/framebuffer/framebuffer.rs
+++ b/charlotte_core/src/framebuffer/framebuffer.rs
@@ -127,7 +127,14 @@ impl FrameBufferInfo {
     /// * `text` - The text to draw.
     /// * `color` - The color of the text in ARGB format.
 
-    pub fn draw_text(&self, mut x: usize, mut y: usize, text: &str, color: u32, background_color: u32) {
+    pub fn draw_text(
+        &self,
+        mut x: usize,
+        mut y: usize,
+        text: &str,
+        color: u32,
+        background_color: u32,
+    ) {
         let start_x = x; // Remember the starting x position to reset to it on new lines
         for c in text.chars() {
             match c {

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -55,7 +55,10 @@ unsafe extern "C" fn main() -> ! {
         }
     }
 
-    println!("[f{:X}Example println with [b{:X}color [f{:X}[b{:X}formatting", Color::RED, Color::YELLOW, Color::GREEN, Color::PURPLE);
+    CONSOLE.lock().set_colors(Color::RED, Color::WHITE);
+    println!("Example of setting console colors");
+    CONSOLE.lock().set_colors(Color::WHITE, Color::BLACK);
+    println!("Example println with [b{:X}color [f{:X}[b{:X}formatting", Color::BLUE, Color::GREEN, Color::MAGENTA);
  
     ArchApi::halt()
 }

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -58,8 +58,13 @@ unsafe extern "C" fn main() -> ! {
     CONSOLE.lock().set_colors(Color::RED, Color::WHITE);
     println!("Example of setting console colors");
     CONSOLE.lock().set_colors(Color::WHITE, Color::BLACK);
-    println!("Example println with [b{:X}color [f{:X}[b{:X}formatting", Color::BLUE, Color::GREEN, Color::MAGENTA);
- 
+    println!(
+        "Example println with [b{:X}color [f{:X}[b{:X}formatting",
+        Color::BLUE,
+        Color::GREEN,
+        Color::MAGENTA
+    );
+
     ArchApi::halt()
 }
 

--- a/charlotte_core/src/main.rs
+++ b/charlotte_core/src/main.rs
@@ -12,13 +12,14 @@ use core::fmt::Write;
 use arch::x86_64::memory::pmm::PFA;
 use arch::{Api, ArchApi};
 
+use framebuffer::colors::Color;
 use framebuffer::console::CONSOLE;
 
 use crate::framebuffer::framebuffer::FRAMEBUFFER;
 
 #[no_mangle]
 unsafe extern "C" fn main() -> ! {
-    FRAMEBUFFER.lock().clear_screen(0x00000000);
+    FRAMEBUFFER.lock().clear_screen(Color::BLACK);
     println!("Hello, world!");
 
     logln!("Initializing BSP");
@@ -54,6 +55,8 @@ unsafe extern "C" fn main() -> ! {
         }
     }
 
+    println!("[f{:X}Example println with [b{:X}color [f{:X}[b{:X}formatting", Color::RED, Color::YELLOW, Color::GREEN, Color::PURPLE);
+ 
     ArchApi::halt()
 }
 


### PR DESCRIPTION
Issue #52
Adds foreground and background color setting to the console + inline color styling for print macros

Current inline styling uses [f or [b to mark the start of a color setting. [f sets foreground color. [b sets background color. We should probably use a better format sequence, but I was having issues with \x1b and I'm tired, so let me know if you have a better idea

Examples of usage can be found in main.rs

This is my first PR for the project, so if I missed any standards or anything, lemme know