### PR TITLE
pmm: multiple bugfixes and cleanups

### DIFF
--- a/charlotte_core/src/memory/address.rs
+++ b/charlotte_core/src/memory/address.rs
@@ -1,0 +1,71 @@
+use core::num::NonZeroUsize;
+use core::ops::Add;
+
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PhysicalAddress(usize);
+
+impl PhysicalAddress {
+    const FRAME_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(4096) };
+    const FRAME_SHIFT: usize = 12;
+
+    #[inline]
+    pub const fn new(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    #[inline]
+    pub const fn bits(&self) -> usize {
+        self.0
+    }
+
+    #[inline]
+    pub const fn pfn(&self) -> usize {
+        self.bits() >> Self::FRAME_SHIFT
+    }
+
+    #[inline]
+    pub const fn from_pfn(pfn: usize) -> Self {
+        Self::new(pfn << Self::FRAME_SHIFT)
+    }
+
+    #[inline]
+    pub const fn is_aligned_to(&self, align: NonZeroUsize) -> bool {
+        self.bits() & (align.get() - 1) == 0
+    }
+
+    #[inline]
+    pub const fn is_page_aligned(&self) -> bool {
+        self.is_aligned_to(Self::FRAME_SIZE)
+    }
+
+    #[inline]
+    pub fn iter_frames(&self, n_frames: usize) -> impl DoubleEndedIterator<Item = PhysicalAddress> {
+        (self.bits()..(self.bits() + n_frames * Self::FRAME_SIZE.get()))
+            .step_by(Self::FRAME_SIZE.get())
+            .map(PhysicalAddress::new)
+    }
+}
+
+impl From<usize> for PhysicalAddress {
+    #[inline]
+    fn from(val: usize) -> Self {
+        Self::new(val)
+    }
+}
+
+impl From<PhysicalAddress> for usize {
+    #[inline]
+    fn from(addr: PhysicalAddress) -> Self {
+        addr.bits()
+    }
+}
+
+impl Add<usize> for PhysicalAddress {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, val: usize) -> Self::Output {
+        Self::new(self.bits() + val)
+    }
+}

--- a/charlotte_core/src/memory/mod.rs
+++ b/charlotte_core/src/memory/mod.rs
@@ -3,5 +3,6 @@
 //! memory in the kernel's address space, allocating and deallocating physical frames, and managing
 //! all virtual address spaces.
 
+pub mod address;
 pub mod pmm;
 pub mod vmm;

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -185,12 +185,10 @@ impl PhysicalFrameAllocator {
                     return Ok(base);
                 }
                 RegionAvailability::Unavailable(last_frame) => {
-                    // skip to the next properly aligned address after the last frame in the gap using the magic of integer division
+                    // skip to the next properly aligned address after the last frame in the gap
                     base = PhysicalAddress::new(
-                        (((last_frame.bits() + FRAME_SIZE) / corrected_alignment) + 1)
-                            * corrected_alignment,
+                        (last_frame.bits() + FRAME_SIZE).next_multiple_of(corrected_alignment),
                     );
-                    continue;
                 }
             }
         }

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -129,13 +129,10 @@ impl PhysicalFrameAllocator {
 
     pub fn allocate(&mut self) -> Result<PhysicalAddress, Error> {
         for (byte_index, byte) in self.bitmap.iter_mut().enumerate() {
-            if *byte != 0xFF {
-                for bit_index in 0..8 {
-                    if *byte & (1 << bit_index) == 0 {
-                        *byte |= 1 << bit_index;
-                        return Ok(byte_index * 8 + bit_index);
-                    }
-                }
+            let bit_index = byte.trailing_ones() as usize;
+            if bit_index < 8 {
+                *byte |= 1 << bit_index;
+                return Ok(self.index_to_address(byte_index, bit_index));
             }
         }
         Err(Error::OutOfMemory)

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -201,7 +201,7 @@ impl PhysicalFrameAllocator {
         if !base.is_page_aligned() {
             return Err(Error::AddressMisaligned);
         }
-        if base.pfn() >= self.frame_capacity() {
+        if base.pfn() >= self.frame_capacity() || base.pfn() + n_frames >= self.frame_capacity() {
             return Err(Error::AddressOutOfRange);
         }
 

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -159,16 +159,12 @@ impl PhysicalFrameAllocator {
         if n_frames == 0 {
             return Err(Error::InvalidSize);
         }
-        if !Self::is_power_of_two(alignment) {
+        if !alignment.is_power_of_two() {
             return Err(Error::AddressMisaligned);
         }
 
         // if the requested alignment is less than the frame size, then the alignment is the frame size
-        let corrected_alignment = if alignment < FRAME_SIZE {
-            FRAME_SIZE
-        } else {
-            alignment
-        };
+        let corrected_alignment = alignment.max(FRAME_SIZE);
 
         let mut base: PhysicalAddress = 0usize;
         while base < self.bitmap.len() - n_frames * FRAME_SIZE {
@@ -243,14 +239,5 @@ impl PhysicalFrameAllocator {
     fn clear_by_address(&mut self, address: PhysicalAddress) {
         let (byte, bit) = self.address_to_index(address);
         self.bitmap[byte] &= !(1 << bit);
-    }
-
-    fn is_power_of_two(x: usize) -> bool {
-        // handle the overflow case
-        if x == 0 {
-            false
-        } else {
-            x & (x - 1) == 0
-        }
     }
 }

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -147,7 +147,7 @@ impl PhysicalFrameAllocator {
         if frame / FRAME_SIZE >= self.bitmap.len() {
             return Err(Error::AddressOutOfRange);
         }
-        self.bitmap[frame / FRAME_SIZE / 8] &= !(1 << (frame / FRAME_SIZE % 8));
+        self.clear_by_address(frame);
         Ok(())
     }
     pub fn allocate_contiguous(

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -125,8 +125,8 @@ impl PhysicalFrameAllocator {
             }
         }
         // set the bits corresponding to the bitmap as unavailable
-        let start_frame = core::ptr::addr_of!(pfa.bitmap) as usize / FRAME_SIZE;
-        let end_frame = (start_frame + pfa.bitmap.len()) / FRAME_SIZE;
+        let start_frame = region.base as usize / FRAME_SIZE;
+        let end_frame = ((region.base + region.length) as usize).div_ceil(FRAME_SIZE);
         for frame in start_frame..end_frame {
             pfa.bitmap[frame / 8] |= 1 << (frame % 8);
         }

--- a/charlotte_core/src/memory/pmm.rs
+++ b/charlotte_core/src/memory/pmm.rs
@@ -170,10 +170,10 @@ impl PhysicalFrameAllocator {
         while base < self.bitmap.len() - n_frames * FRAME_SIZE {
             match self.check_region(base, n_frames) {
                 RegionAvailability::Available => {
-                    for addr in (base..base + n_frames).step_by(FRAME_SIZE) {
+                    for addr in (base..base + n_frames * FRAME_SIZE).step_by(FRAME_SIZE) {
                         self.set_by_address(addr);
                     }
-                    return Ok(base * FRAME_SIZE);
+                    return Ok(base);
                 }
                 RegionAvailability::Unavailable(last_frame) => {
                     // skip to the next properly aligned address after the last frame in the gap using the magic of integer division
@@ -215,7 +215,7 @@ impl PhysicalFrameAllocator {
         // if a gap is found, the method can continue searching from after the gap
         for i in (0..n_frames).rev() {
             let address = base + i * FRAME_SIZE;
-            if self.get_by_address(address) == true {
+            if self.get_by_address(address) {
                 return RegionAvailability::Unavailable(address);
             }
         }


### PR DESCRIPTION
Fix multiple arithmetic and logic bugs in the PMM. Also, add some code cleanups, and replace the `PhysicalAddress` typedef with an actual type.