### PR TITLE
Fix UB causing errors in reading MADT entries

### DIFF
--- a/charlotte_core/src/acpi/madt.rs
+++ b/charlotte_core/src/acpi/madt.rs
@@ -1,7 +1,6 @@
 //! MADT Parsing facilities
-use core::mem;
-
 use crate::acpi::tables::{get_table, SDTHeader};
+use core::mem;
 
 /// The MADT
 pub struct Madt {
@@ -40,7 +39,7 @@ impl Madt {
         MadtIter {
             addr: self.addr + mem::size_of::<SDTHeader>() + 8, // Skip over the header, the local APIC address and flags
             offset: 0,
-            len: self.header.length() as usize,
+            len: self.header.length() as usize - mem::size_of::<SDTHeader>() - 8,
         }
     }
 }
@@ -58,11 +57,6 @@ impl Iterator for MadtIter {
     fn next(&mut self) -> Option<Self::Item> {
         if self.offset < self.len {
             let header = unsafe { &*((self.addr + self.offset) as *const MadtEntryHeader) };
-
-            // FIXME: w/a for arm64
-            if header.length == 0 {
-                return None;
-            }
 
             let entry = match header.entry_type {
                 0 => MadtEntry::ProcessorLocalApic(unsafe {


### PR DESCRIPTION
The current MADT entry iterator runs into undefined behaviour when attempting to iterate through the MADT's entries.

The MADT iterator keeps track of the starting address of the MADT's entries, the offset into the MADT (i.e. which entry the iterator is currently reading), and the total length of the MADT which is used as an upper bound. The way this upper bound is handled is by checking `self.offset < self.len`. The problem is that the length was being initialized to the total length of the MADT declared in the header, while the offset represented how many bytes we were past the header, causing us to read through the MADT entries and then continuing to read past the MADT in memory, resulting in garbage entries (such as entries with invalid types or entries with 0 lengths).

This is fixed by properly calculating the iterator's upper bound by subtracting the length of the MADT header from the iterator's `len` field. 