### PR TITLE
Add lint warning for undocumented `unsafe` blocks

### DIFF
--- a/charlotte_core/Cargo.toml
+++ b/charlotte_core/Cargo.toml
@@ -32,5 +32,8 @@ suspicious = { level = "deny", priority = -1 }
 perf = { level = "deny", priority = -1 }
 complexity = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
+
+undocumented_unsafe_blocks = { level = "warn" }
+
 # Relax some lints because we don't support 32-bit targets
-enum_clike_unportable_variant = {level = "allow", priority = -10}
+enum_clike_unportable_variant = { level = "allow", priority = -10 }


### PR DESCRIPTION
As requested, `unsafe` blocks have to be documented. The lint is described both [here](https://std-dev-guide.rust-lang.org/policy/safety-comments.html) and [here](https://rust-lang.github.io/rust-clippy/master/#/undocumented_unsafe_blocks).