### PR TITLE
Fixed serial port welcome

### DIFF
--- a/charlotte_core/src/kmon.rs
+++ b/charlotte_core/src/kmon.rs
@@ -63,7 +63,7 @@ impl<T: Serial> Kmon<T> {
     }
 
     pub fn repl_loop(&mut self) {
-        log!("=================== [Serial Prompt v1.0] ===================\n");
+        log!("=================== Serial Prompt v1.0 =====================\n");
         self.print_term_begin();
         loop {
             let c = self.port.read_char();


### PR DESCRIPTION
The welcome to the serial port says "erial port" instead of serial port, this should fix that issue